### PR TITLE
chore: Point dependabot to gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
+ - package-ecosystem: "gomod"
    directory: "/"
    schedule:
      interval: weekly


### PR DESCRIPTION
Updating dependabot to gomod as per https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem- so it can discover out of date dependencies and raise PRs to resolve those automatically.