### PR TITLE
chore(dependabot): group bumps and add devcontainers ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,41 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
+# Group dependabot bumps by risk so weekly churn stays at 1–3 PRs:
+# - patches: all patch bumps across all deps    (safe, fast/auto-merge candidate)
+# - minor:   all minor bumps                     (review-light)
+# - major:   all major bumps                     (review-heavy, still bundled)
+# Security advisories ignore groups by default — they get individual PRs.
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:
- - package-ecosystem: "gomod"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      patches:
+        update-types:
+          - "patch"
+      minor:
+        update-types:
+          - "minor"
+      major:
+        update-types:
+          - "major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      devcontainers:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
Cuts dependabot PR churn by grouping weekly updates and expands coverage to the devcontainer base image.

**gomod** — grouped by risk (not vendor), so weekly churn stays at 1–3 PRs:
- **patches** — all patch bumps across all deps (safe, auto-merge candidate)
- **minor** — all minor bumps (review-light)
- **major** — all major bumps (review-heavy, still bundled)

**github-actions** — all action updates in one PR.

**devcontainers** — newly enabled. Keeps `mcr.microsoft.com/devcontainers/go:1.25-bookworm` (and any features) in `.devcontainer/devcontainer.json` up to date.

Security advisories ignore groups by default — they still get individual PRs, by design.

## Test plan
- [ ] After next scheduled run (Monday), confirm a single grouped PR per group instead of one-per-module
- [ ] Verify a security advisory still opens as its own PR
- [ ] Confirm devcontainer base image starts receiving bumps