### PR TITLE
fix(docs): set mike default alias and trim workflow perms

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: write    # mike commits to gh-pages branch
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-${{ github.ref }}
@@ -41,7 +39,9 @@ jobs:
 
       - name: Deploy latest (push to main)
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: mike deploy --push --update-aliases main latest
+        run: |
+          mike deploy --push --update-aliases main latest
+          mike set-default --push latest
 
       - name: Deploy versioned (tag push)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write    # mike commits to gh-pages branch
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-deploy
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- Set `latest` as mike's default alias on `main` pushes so the bare Pages URL serves docs instead of 404.
- Trim unused `pages: write` / `id-token: write` workflow permissions (mike pushes to `gh-pages` branch directly; only `contents: write` is used). Resolves CodeRabbit's least-privilege note.

## Test plan
- [x] Verified site is currently live at `/latest/` but 404 at root
- [ ] After merge: confirm https://tink3rlabs.github.io/magic/ returns 200 and redirects to `/latest/`
- [ ] Confirm docs workflow still passes with reduced permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)