### PR TITLE
docs: serve llms.txt and per-page markdown for LLM consumers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
     - navigation.top
     - content.code.copy
     - content.action.edit
+    - content.action.view
     - search.suggest
     - search.highlight
   palette:
@@ -49,6 +50,22 @@ nav:
 
 not_in_nav: |
   observability-internals.md
+
+plugins:
+  - search
+  - llmstxt:
+      full_output: llms-full.txt
+      sections:
+        Overview:
+          - index.md
+        Guides:
+          - getting-started.md
+          - tutorial.md
+          - lucene.md
+          - storage.md
+          - observability.md
+        Contributing:
+          - contributing.md
 
 markdown_extensions:
   - admonition

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
 mkdocs-material==9.5.44
 mike==2.1.3
+mkdocs-llmstxt==0.5.0


### PR DESCRIPTION
## Summary

Makes the docs site consumable by LLMs and agents as **text**, not rendered HTML — addresses the pushback on shipping more HTML chrome before improving how the existing markdown is served.

Three entry points after this PR:

- **`/llms.txt`** — short, curated index per the [llmstxt.org spec](https://llmstxt.org). Lists each guide with its URL pointing at the raw `.md`.
- **`/llms-full.txt`** — entire site concatenated as plain markdown (~2.4k lines today). Single-file ingest for embedding pipelines / RAG.
- **"View source"** button next to "Edit this page" on every page → links to the raw `.md` on GitHub for one-off agent access.

## Changes

- `requirements-docs.txt` — add `mkdocs-llmstxt==0.5.0` (pure Python, no new native deps; Cairo etc. are not required for this plugin)
- `mkdocs.yml`
  - add `content.action.view` Material feature
  - add `plugins:` block with `search` (re-declared because adding the section disables the default) and `llmstxt` configured with curated sections matching the existing nav

## Verification

```
$ mkdocs build --strict
INFO    -  Documentation built in 0.64 seconds

$ ls site/llms*.txt
-rw-r--r-- … 99221 … site/llms-full.txt
-rw-r--r-- …   584 … site/llms.txt
```

`site/llms.txt`:
```
# magic

> Common building blocks for Go microservices, so your service code can focus on business logic.

## Overview
- [Home](https://tink3rlabs.github.io/magic/index.md)

## Guides
- [Getting Started](https://tink3rlabs.github.io/magic/getting-started/index.md)
- [Search (Lucene)](https://tink3rlabs.github.io/magic/lucene/index.md)
- [Storage Adapters](https://tink3rlabs.github.io/magic/storage/index.md)
- [Observability](https://tink3rlabs.github.io/magic/observability/index.md)

## Contributing
- [Contributing](https://tink3rlabs.github.io/magic/contributing/index.md)
```

## Test plan

- [ ] CI's `Docs` workflow builds without errors
- [ ] After merge: `https://tink3rlabs.github.io/magic/latest/llms.txt` resolves
- [ ] After merge: `https://tink3rlabs.github.io/magic/latest/llms-full.txt` resolves
- [ ] After merge: a page header shows the new "View source" eye icon next to the edit pencil

## Out of scope (future)

- Per-page lead summaries to improve llms.txt entries (content work, not plumbing)
- Standardizing code-block titles for better chunk metadata
- A hand-curated `llms.txt` override (the auto-generated one is good enough for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added search functionality to documentation
  * Enabled enhanced view action feature in Material theme
  * Configured structured documentation export with section mapping

* **Chores**
  * Added documentation processing dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tink3rlabs/magic/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->