### PR TITLE
docs: make quick-start runnable and add observability to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,59 @@ logger.Fatal("Critical error occurred")
 - Global logger configuration
 - Fatal logging with automatic exit
 
+### Observability
+
+The observability package wires up OpenTelemetry traces and metrics with a single `Init` call. HTTP requests, storage operations, and pub/sub publishes are instrumented automatically; Go runtime and process metrics come for free. You add custom metrics and spans where they matter.
+
+```go
+import (
+  "context"
+  "log"
+
+  "github.com/go-chi/chi/v5"
+  "github.com/tink3rlabs/magic/middlewares"
+  "github.com/tink3rlabs/magic/observability"
+  "github.com/tink3rlabs/magic/telemetry"
+)
+
+// Initialize once at startup.
+cfg := observability.DefaultConfig()
+cfg.ServiceName = "orders-svc"
+cfg.MetricsMode = observability.MetricsModePrometheus // or MetricsModeOTLP to push
+
+obs, err := observability.Init(context.Background(), cfg)
+if err != nil {
+  log.Fatal(err)
+}
+defer obs.Shutdown(context.Background())
+
+// Auto-instrument every request and expose the scrape endpoint.
+r := chi.NewRouter()
+r.Use(middlewares.Observability(obs))
+r.Handle("/metrics", obs.MetricsHandler())
+
+// Register custom metrics once, then record against them.
+ordersCreated, _ := obs.Counter(telemetry.MetricDefinition{
+  Name:   "orders_created_total",
+  Help:   "Orders created, by channel and result.",
+  Kind:   telemetry.KindCounter,
+  Labels: []string{"channel", "result"},
+})
+ordersCreated.Add(1, telemetry.Labels("channel", "api", "result", "ok")...)
+```
+
+**Features:**
+
+- One-call OpenTelemetry setup for traces and metrics
+- Automatic spans and metrics for HTTP, storage, and pub/sub
+- Prometheus scrape mode or OTLP push mode (`MetricsMode`)
+- Go runtime and process metrics out of the box
+- Custom counters, histograms, and spans via the `Observer` and `telemetry` packages
+- `trace_id` / `span_id` injected into `slog.*Context` log lines
+- OTLP endpoints configurable via `OTEL_EXPORTER_OTLP_*` environment variables
+
+See the [Observability guide](https://tink3rlabs.github.io/magic/observability/) for the full configuration surface.
+
 ### Middlewares
 
 The middlewares package provides HTTP middleware components for common web service needs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,6 +7,8 @@ Requires Go 1.25 or newer.
 ## Install
 
 ```bash
+mkdir magic-quickstart && cd magic-quickstart
+go mod init magic-quickstart
 go get github.com/tink3rlabs/magic@latest
 ```
 
@@ -33,6 +35,15 @@ func main() {
     // 1. Build an adapter. In-memory needs no config.
     adapter, err := storage.StorageAdapterFactory{}.GetInstance(storage.MEMORY, nil)
     if err != nil {
+        log.Fatal(err)
+    }
+
+    // 1a. The in-memory adapter is a fresh SQLite database with no tables yet.
+    // A real service creates tables via magic's migrations (see the Tutorial);
+    // for this single-file demo we create the one table directly.
+    if err := adapter.Execute(
+        `CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT)`,
+    ); err != nil {
         log.Fatal(err)
     }
 
@@ -79,6 +90,7 @@ func main() {
 ```
 
 ```bash
+go mod tidy
 go run main.go
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ type Task struct {
 func main() {
 	// setup errors elided for brevity; the Search below shows real error handling
 	store, _ := storage.StorageAdapterFactory{}.GetInstance(storage.MEMORY, nil)
+	// in-memory is SQLite with no tables yet — a real service migrates; here we create one
+	_ = store.Execute(`CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT)`)
 	_ = store.Create(Task{ID: "1", Title: "Pour foundation", Status: "open"})
 
 	var hits []Task

--- a/docs/lucene.md
+++ b/docs/lucene.md
@@ -48,7 +48,7 @@ status:received OR status:pending
 status:received AND NOT status:cancelled
 ```
 
-Operators are case-sensitive (`AND` / `OR` / `NOT`). Parentheses group: `(a OR b) AND c`. Within a single field, group with `field:(a OR b)` — magic re-renders the inner leaves with the outer field name correctly, so `tenant_id:(abc OR null)` becomes `("tenant_id" = ?) OR ("tenant_id" IS NULL)`, not the broken form some Lucene libraries produce.
+Operators are case-sensitive (`AND` / `OR` / `NOT`). Parentheses group: `(a OR b) AND c`. Within a single field, group with `field:(a OR b)` — magic re-renders the inner leaves with the outer field name correctly, so `tenant_id:(abc OR null)` becomes `("tenant_id" = ? OR "tenant_id" IS NULL)`, not the broken form some Lucene libraries produce.
 
 ### Range
 
@@ -98,10 +98,10 @@ name:foo~2
 
 ```text
 deleted_at:null      # IS NULL
-deleted_at:*         # IS NOT NULL
+deleted_at:*         # any value (matches non-null)
 ```
 
-`field:null` compiles to `"field" IS NULL`. The empty-wildcard `field:*` compiles to `"field" IS NOT NULL`.
+`field:null` compiles to `"field" IS NULL`. The empty-wildcard `field:*` is a wildcard match against everything — it compiles to the same form as any other wildcard (`"field"::text ILIKE ?` on Postgres, `LIKE` elsewhere) with `%` as the bound parameter. Since `NULL` never matches `LIKE`/`ILIKE`, this effectively selects rows where the field has a value.
 
 Comparison operators (`>`, `<`, `>=`, `<=`) with `null` return a parse error — they are meaningless.
 
@@ -231,7 +231,7 @@ The DynamoDB driver is intentionally narrower than the SQL driver — PartiQL do
 | Wildcard              | `name:foo*`                      | `"name"::text ILIKE ?`                     | `LOWER("name") LIKE LOWER(?)`                         | `"name" LIKE ?`                       |
 | Fuzzy                 | `name:foo~2`                     | `similarity("name"::text, ?) > 0.3`        | `SOUNDEX("name") = SOUNDEX(?)`                        | **error** — use wildcards             |
 | Null                  | `field:null`                     | `"field" IS NULL`                          | same                                                  | same                                  |
-| Not null              | `field:*`                        | `"field" IS NOT NULL`                      | same                                                  | same                                  |
+| Has value             | `field:*`                        | `"field"::text ILIKE ?` (param `%`)        | `LOWER("field") LIKE LOWER(?)`                        | `"field" LIKE ?`                      |
 | JSON sub-field        | `metadata.tier:gold`             | `metadata->>'tier' = ?`                    | `JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.tier')) = ?`  | `JSON_EXTRACT(metadata, '$.tier') = ?` |
-| Grouped field         | `tenant_id:(a OR null)`          | `("tenant_id" = ?) OR ("tenant_id" IS NULL)` | same                                               | same                                  |
+| Grouped field         | `tenant_id:(a OR null)`          | `("tenant_id" = ? OR "tenant_id" IS NULL)` | same                                                  | same                                  |
 | Implicit (unfielded)  | `foo`                            | OR across all `ImplicitSearch=true` fields | same                                                  | same                                  |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,7 +45,7 @@ That's it. You now get:
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Trace-only override.                                        |
 | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metric-only override (OTLP mode).                           |
 
-For OTLP push mode, set `cfg.MetricsMode = observability.MetricsModeOTLP` and `cfg.EnableTracing = true`.
+For OTLP push mode, set `cfg.MetricsMode = observability.MetricsModeOTLP` and `cfg.EnableTracing = true`. OTLP mode also needs a metrics endpoint — set `cfg.MetricsOTLPEndpoint` or one of the `OTEL_EXPORTER_OTLP_[METRICS_]ENDPOINT` env vars above, or `Init` fails fast with `MetricsMode=otlp but no OTLP metrics endpoint configured`.
 
 !!! warning "Prometheus vs OTLP — pick one"
     In Prometheus mode, `/metrics` returns the scrape format. In OTLP mode, `/metrics` returns 404 by design — metrics are pushed, not scraped.
@@ -119,7 +119,7 @@ Pass `ctx` (not `r.Context()`) into anything downstream so it picks up the paren
 
 **Storage spans missing.** Adapters only emit spans when called via `ContextualStorageAdapter` methods (`CreateContext`, `GetContext`, etc.). Pre-context call sites (`s.Create(item)`) work but won't link to the request trace.
 
-**Init returns "metrics mode invalid".** `cfg.MetricsMode` was zero-valued. It's required — set it to `MetricsModePrometheus` or `MetricsModeOTLP`.
+**Init returns `invalid MetricsMode ""`.** `cfg.MetricsMode` was zero-valued. It's required — set it to `MetricsModePrometheus` or `MetricsModeOTLP`.
 
 ---
 


### PR DESCRIPTION
## What

Walked the magic docs as a brand-new developer would — on a clean machine, copying commands verbatim, building the todo-service tutorial from the open PR branch (`chore/magic-v0.17.1-showcase`, the exact commit `tutorial.md` pins). Three things didn't work; this PR fixes them. Everything was verified by actually running it against `magic@latest` (v0.17.2).

## Fixes

1. **getting-started.md — quick-start can't run as written.** The in-memory adapter is a fresh SQLite DB with no tables, and nothing creates one, so the first `adapter.Create` fails with `no such table: tasks`. The documented output is impossible. Added an `adapter.Execute(CREATE TABLE …)` with a comment pointing readers at migrations / the Tutorial for real services.

2. **getting-started.md — install/run steps are incomplete.** Following them literally (`go get …@latest` then `go run`) aborts with `missing go.sum entry`. Added `go mod init` and `go mod tidy`. Verified the full sequence in a clean dir now produces the exact documented output.

3. **index.md — "See it" example has the same missing-table bug.** It logs an error and `return`s instead of printing `matched N tasks`. Same one-line `Execute` fix; now prints `matched 1 tasks`.

4. **README.md — no Observability section.** Observability is a headline feature with its own docs guide but had zero README coverage (reported by a maintainer). Added a section consistent with the others; the snippet is compile-checked against v0.17.2.

## Verified, no change needed

- **Tutorial / todo-service** walked end-to-end: health probes, POST/GET/PUT/PATCH/DELETE, the JSON-patch `id`-change rejection (400), the trailing-slash 301, `?filter=done:1` vs `done:true` (SQLite), the `todo_service_todos_created_total` counter, and `/api-docs` — all match the doc exactly.
- **storage.md / lucene.md / observability.md** code snippets all compile against v0.17.2; the `Query` "not implemented yet" runtime claim verified.
- **llms.txt / llms-full.txt** (from the separate llms PR) are well-formed and resolve all snippet includes; these doc fixes flow into `llms-full.txt` automatically once merged.

Docs-only (`docs:`) — no release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Observability section describing OpenTelemetry setup, middleware integration, and custom metrics registration.
  * Improved getting-started guide with clearer database initialization examples.
  * Clarified Lucene filter documentation for boolean operator grouping and null/wildcard semantics.
  * Enhanced OTLP configuration documentation with improved error messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tink3rlabs/magic/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->