### PR TITLE
fix: forward params in MemoryAdapter so sort direction is honored

### DIFF
--- a/storage/memory.go
+++ b/storage/memory.go
@@ -97,7 +97,7 @@ func (m *MemoryAdapter) Create(item any, params ...map[string]any) error {
 }
 
 func (m *MemoryAdapter) CreateContext(ctx context.Context, item any, params ...map[string]any) error {
-	return m.DB.CreateContext(ctx, item)
+	return m.DB.CreateContext(ctx, item, params...)
 }
 
 func (m *MemoryAdapter) Get(dest any, filter map[string]any, params ...map[string]any) error {
@@ -105,7 +105,7 @@ func (m *MemoryAdapter) Get(dest any, filter map[string]any, params ...map[strin
 }
 
 func (m *MemoryAdapter) GetContext(ctx context.Context, dest any, filter map[string]any, params ...map[string]any) error {
-	return m.DB.GetContext(ctx, dest, filter)
+	return m.DB.GetContext(ctx, dest, filter, params...)
 }
 
 func (m *MemoryAdapter) Update(item any, filter map[string]any, params ...map[string]any) error {
@@ -113,7 +113,7 @@ func (m *MemoryAdapter) Update(item any, filter map[string]any, params ...map[st
 }
 
 func (m *MemoryAdapter) UpdateContext(ctx context.Context, item any, filter map[string]any, params ...map[string]any) error {
-	return m.DB.UpdateContext(ctx, item, filter)
+	return m.DB.UpdateContext(ctx, item, filter, params...)
 }
 
 func (m *MemoryAdapter) Delete(item any, filter map[string]any, params ...map[string]any) error {
@@ -121,7 +121,7 @@ func (m *MemoryAdapter) Delete(item any, filter map[string]any, params ...map[st
 }
 
 func (m *MemoryAdapter) DeleteContext(ctx context.Context, item any, filter map[string]any, params ...map[string]any) error {
-	return m.DB.DeleteContext(ctx, item, filter)
+	return m.DB.DeleteContext(ctx, item, filter, params...)
 }
 
 func (m *MemoryAdapter) List(dest any, sortKey string, filter map[string]any, limit int, cursor string, params ...map[string]any) (string, error) {
@@ -129,7 +129,7 @@ func (m *MemoryAdapter) List(dest any, sortKey string, filter map[string]any, li
 }
 
 func (m *MemoryAdapter) ListContext(ctx context.Context, dest any, sortKey string, filter map[string]any, limit int, cursor string, params ...map[string]any) (string, error) {
-	return m.DB.ListContext(ctx, dest, sortKey, filter, limit, cursor)
+	return m.DB.ListContext(ctx, dest, sortKey, filter, limit, cursor, params...)
 }
 
 func (m *MemoryAdapter) Search(dest any, sortKey string, query string, limit int, cursor string, params ...map[string]any) (string, error) {
@@ -137,7 +137,7 @@ func (m *MemoryAdapter) Search(dest any, sortKey string, query string, limit int
 }
 
 func (m *MemoryAdapter) SearchContext(ctx context.Context, dest any, sortKey string, query string, limit int, cursor string, params ...map[string]any) (string, error) {
-	return m.DB.SearchContext(ctx, dest, sortKey, query, limit, cursor)
+	return m.DB.SearchContext(ctx, dest, sortKey, query, limit, cursor, params...)
 }
 
 func (m *MemoryAdapter) Count(dest any, filter map[string]any, params ...map[string]any) (int64, error) {
@@ -145,7 +145,7 @@ func (m *MemoryAdapter) Count(dest any, filter map[string]any, params ...map[str
 }
 
 func (m *MemoryAdapter) CountContext(ctx context.Context, dest any, filter map[string]any, params ...map[string]any) (int64, error) {
-	return m.DB.CountContext(ctx, dest, filter)
+	return m.DB.CountContext(ctx, dest, filter, params...)
 }
 
 func (m *MemoryAdapter) Query(dest any, statement string, limit int, cursor string, params ...map[string]any) (string, error) {
@@ -153,5 +153,5 @@ func (m *MemoryAdapter) Query(dest any, statement string, limit int, cursor stri
 }
 
 func (m *MemoryAdapter) QueryContext(ctx context.Context, dest any, statement string, limit int, cursor string, params ...map[string]any) (string, error) {
-	return m.DB.QueryContext(ctx, dest, statement, limit, cursor)
+	return m.DB.QueryContext(ctx, dest, statement, limit, cursor, params...)
 }

--- a/storage/memory_sortdirection_test.go
+++ b/storage/memory_sortdirection_test.go
@@ -1,0 +1,59 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/tink3rlabs/magic/storage"
+)
+
+// sortDirRow uses a dedicated table so it can run against the shared
+// in-memory adapter singleton without colliding with other tests.
+type sortDirRow struct {
+	ID string `json:"id"`
+}
+
+func (sortDirRow) TableName() string { return "memtest_sortdir" }
+
+// The in-memory adapter delegates to an embedded SQLAdapter. It must forward
+// the variadic params (which carry SortDirectionKey) so that ordering and
+// validation behave the same as the SQL adapter — see storage/memory.go.
+func TestMemoryAdapterForwardsSortDirection(t *testing.T) {
+	adapter, err := storage.StorageAdapterFactory{}.GetInstance(storage.MEMORY, nil)
+	if err != nil {
+		t.Fatalf("GetInstance(MEMORY): %v", err)
+	}
+	if err := adapter.Execute(`CREATE TABLE IF NOT EXISTS memtest_sortdir (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Execute(`DROP TABLE IF EXISTS memtest_sortdir`) })
+
+	for _, id := range []string{"01", "02", "03"} {
+		if err := adapter.Create(sortDirRow{ID: id}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	var desc []sortDirRow
+	if _, err := adapter.List(&desc, "id", nil, 10, "", map[string]any{storage.SortDirectionKey: "DESC"}); err != nil {
+		t.Fatalf("list DESC: %v", err)
+	}
+	got := []string{}
+	for _, r := range desc {
+		got = append(got, r.ID)
+	}
+	want := []string{"03", "02", "01"}
+	if len(got) != len(want) {
+		t.Fatalf("DESC list length = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DESC ordering = %v, want %v (SortDirectionKey was dropped?)", got, want)
+		}
+	}
+
+	// An invalid direction must surface an error, not be silently ignored.
+	var bad []sortDirRow
+	if _, err := adapter.List(&bad, "id", nil, 10, "", map[string]any{storage.SortDirectionKey: "sideways"}); err == nil {
+		t.Fatalf("invalid sort direction returned no error; want error")
+	}
+}


### PR DESCRIPTION
## Bug

`MemoryAdapter` delegates every `*Context` method to its embedded `SQLAdapter`, but **dropped the variadic `params`** on the way through:

```go
func (m *MemoryAdapter) ListContext(ctx, dest, sortKey, filter, limit, cursor string, params ...map[string]any) (string, error) {
    return m.DB.ListContext(ctx, dest, sortKey, filter, limit, cursor) // params lost
}
```

`params` is where `SortDirectionKey` lives. So on the in-memory adapter:
- `List`/`Search` with `map[string]any{storage.SortDirectionKey: "DESC"}` was **silently ignored** — results always ascending.
- An **invalid** direction value produced **no error**, though `extractSortDirection` is meant to reject it.

This contradicts the [Storage guide](https://tink3rlabs.github.io/magic/storage/#sort-direction), the quick-start ("flip with `SortDirectionKey: DESC`"), and the adapter's own doc comment ("all `*Context` methods delegate to the embedded `SQLAdapter` so request-scoped context matches production SQL behavior"). It also undermines the core "swap MEMORY for SQL and your code keeps working" promise — code tested on memory would behave differently on Postgres.

## Fix

Forward `params...` in all eight delegations (`Create`/`Get`/`Update`/`Delete`/`List`/`Search`/`Count`/`Query`). The SQL layer already accepts and handles them.

## Test

Added `TestMemoryAdapterForwardsSortDirection`: inserts three rows, asserts `DESC` returns them in descending order, and asserts an invalid direction errors. It **fails against the old code** (`DESC ordering = [01 02 03], want [03 02 01]`) and passes now. `go vet ./...` and `go test ./...` are green.

## How it was found

Running the storage guide's documented examples on a clean machine — not just compiling them. A separate docs PR (#193) fixes unrelated doc inaccuracies found in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)