### PR TITLE
fix(mql): terminate parse loop on quoted value as final token

### DIFF
--- a/mql/parser.go
+++ b/mql/parser.go
@@ -178,9 +178,16 @@ func (p *Parser) parseValueFromPos(startPos int) string {
 		}
 		if endIdx < len(p.input) {
 			val := p.input[startIdx+1 : endIdx]
-			// Advance scanner past the quoted string
+			// Advance scanner past the quoted string. When the closing quote is
+			// the final character, the scanner is already at EOF and next() no
+			// longer advances its offset, so guard on forward progress to avoid
+			// looping forever (issue #221).
 			for p.s.Pos().Offset-1 < endIdx+1 {
+				prev := p.s.Pos().Offset
 				p.next()
+				if p.s.Pos().Offset == prev {
+					break // scanner reached EOF, no further progress possible
+				}
 			}
 			return val
 		}

--- a/mql/parser_test.go
+++ b/mql/parser_test.go
@@ -1,0 +1,59 @@
+package mql
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseQuotedValueAsFinalToken guards against a regression where a quoted
+// value appearing as the final token of the input caused Parser.Parse to spin
+// forever in parseValueFromPos: at EOF the scanner stops advancing its offset,
+// so the scanner-advance loop's condition never becomes false (issue #221).
+//
+// Each case is parsed in a goroutine so the test fails via timeout instead of
+// hanging the whole suite if the loop ever regresses.
+func TestParseQuotedValueAsFinalToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		key   string
+		value string
+	}{
+		{"single-char quoted final value", `k:"v"`, "k", "v"},
+		{"word quoted final value", `name:"alice"`, "name", "alice"},
+		{"quoted final value with space", `k:"hello world"`, "k", "hello world"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			type parseResult struct {
+				expr Expr
+				err  error
+			}
+			done := make(chan parseResult, 1)
+			go func() {
+				expr, err := NewParser(tt.input).Parse()
+				done <- parseResult{expr, err}
+			}()
+
+			select {
+			case r := <-done:
+				if r.err != nil {
+					t.Fatalf("Parse(%q) returned error: %v", tt.input, r.err)
+				}
+				term, ok := r.expr.(*TermExpr)
+				if !ok {
+					t.Fatalf("Parse(%q) = %T, want *TermExpr", tt.input, r.expr)
+				}
+				if term.Key != tt.key {
+					t.Errorf("Parse(%q) key = %q, want %q", tt.input, term.Key, tt.key)
+				}
+				if term.Value != tt.value {
+					t.Errorf("Parse(%q) value = %v, want %q", tt.input, term.Value, tt.value)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Parse(%q) did not terminate within 2s (infinite loop)", tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`mql.NewParser(...).Parse()` loops forever on any query where a **quoted value is the final token**, e.g. `k:"v"` or `name:"alice"`. This is a denial-of-service hazard for any code that parses untrusted MQL input on a request path.

Fixes #221.

## Root cause

In `mql/parser.go`, `parseValueFromPos` advances the scanner past a quoted string with:

```go
for p.s.Pos().Offset-1 < endIdx+1 {
    p.next()
}
```

When the closing quote is the last character of the input, `endIdx+1 == len(input)`. The scanner is already at EOF, so `next()` no longer advances `Offset` (it caps at the input length). The condition `len(input)-1 < len(input)` stays true forever, and the loop never terminates.

Non-final quoted values happen to work only because later tokens push `Offset` past the threshold, letting the loop exit.

## Fix

Guard the loop on forward progress — break as soon as `next()` fails to advance the scanner offset (i.e. EOF):

```go
for p.s.Pos().Offset-1 < endIdx+1 {
    prev := p.s.Pos().Offset
    p.next()
    if p.s.Pos().Offset == prev {
        break // scanner reached EOF, no further progress possible
    }
}
```

## Compatibility — not a breaking change

This is a strict bug fix; no exported API, signature, or type changes.

- **The new `break` is unreachable for any input that already terminated.** It fires only when `next()` fails to advance the scanner offset, which `text/scanner` does only at EOF. Any previously-terminating input satisfied the original exit condition (`Offset-1 < endIdx+1` going false) *before* reaching EOF, so the added branch is never taken and the returned value and final scanner position are identical.
- **The only inputs whose behavior changes are the ones that previously hung** (quoted value as the final token). They never returned, so no caller could depend on the old behavior — they now parse to the correct `TermExpr`.
- **Adjacent paths are untouched.** An unclosed quote (`k:"unclosed`) never enters this block (`endIdx == len(input)`) and still falls through to the unquoted-value path unchanged.

A differential battery over quoted/unquoted/dotted-key/compound/unclosed-quote/wildcard inputs produced identical results to the pre-fix parser on every input that didn't hang.

## Test

Adds `TestParseQuotedValueAsFinalToken` in a new `mql/parser_test.go`. Each case parses in a goroutine and asserts termination within a timeout, so a future regression fails the suite instead of hanging it. It also asserts the parsed key/value are correct. The test hangs (times out) against the old code and passes against the fix.

```
$ go test ./mql/ -run TestParseQuotedValueAsFinalToken
ok  	github.com/tink3rlabs/magic/mql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential unresponsive/hanging behavior when parsing quoted values at end-of-input.
  * Quoted values that are the final token—including cases with trailing spaces—now parse reliably.

* **Tests**
  * Added automated coverage to ensure quoted values used as the final query token parse successfully without timing out, including inputs with trailing spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->